### PR TITLE
Fix bug where multiple choice poll was not correct

### DIFF
--- a/src/commands/administration/polls.js
+++ b/src/commands/administration/polls.js
@@ -43,7 +43,7 @@ class Polls extends Command {
     isAuthorized(member, roles).then((err) => {
       if (!err) {
         const choiceArray = polls.split('--');
-        const question = choiceArray.pop();
+        const question = choiceArray.shift();
         if (choiceArray.length <= 2) {
           return msg.reply(`**You need to have at least 3 choices**\n${helper}`);
         }


### PR DESCRIPTION
To match the syntax, we have to get the question from the front of the choice array and not from its back